### PR TITLE
Different Ldap tree structure for trash

### DIFF
--- a/facts/cpanel_orphan_homes.rb
+++ b/facts/cpanel_orphan_homes.rb
@@ -10,7 +10,7 @@ Facter.add(:cpanel_orphan_homes) do
     #build hash with users that are not in ldap anymore
     orphanhomes = {}
     #get all users deleted from ldap (sftp and ssh users)
-    users=Facter::Util::Resolution.exec('ldapsearch -H ldapi:// -Y EXTERNAL -LLL -s one -b "ou=users,ou=trash,dc=example,dc=tld" "(&(objectClass=person)(status=totrash))" | grep uid: | sed "s|.*: \(.*\)|\1|"')
+    users=Facter::Util::Resolution.exec('ldapsearch -H ldapi:// -Y EXTERNAL -LLL -s one -b "ou=users,ou=trash,dc=example,dc=tld" "(&(objectClass=person)(status=applicationProcess))" | grep cn: | sed "s|.*: \(.*\)|\1|"')
     if not users.nil?
       #to prevent id command (below) to retrive cached data (user ids of nonexistent users) flush here passwd cache table of nscd
       cleannscdcache = Facter::Core::Execution.execute('nscd -i passwd')
@@ -18,8 +18,8 @@ Facter.add(:cpanel_orphan_homes) do
         #confirm user doesn't exist in the system, then add to orphanhomes
         #doc: https://tickets.puppetlabs.com/browse/FACT-1284
         if not Facter::Core::Execution.execute('/usr/bin/id -u ' + user.strip  + ' > /dev/null 2>&1 && echo true || echo false') == "true"
-         userhome = Facter::Util::Resolution.exec('ldapsearch -H ldapi:// -Y EXTERNAL -LLL -s base -b "uid=' + user.strip + ',ou=users,ou=trash,dc=example,dc=tld" "(&(objectClass=person)(status=totrash))" | grep homeDirectory: | sed "s|.*: \(.*\)|\1|"')
-         trashname = Facter::Util::Resolution.exec('ldapsearch -H ldapi:// -Y EXTERNAL -LLL -s base -b "uid=' + user.strip + ',ou=users,ou=trash,dc=example,dc=tld" "(&(objectClass=person)(status=totrash))" | grep type: | sed "s|.*: \(.*\)|\1|"')
+         userhome = Facter::Util::Resolution.exec('ldapsearch -H ldapi:// -Y EXTERNAL -LLL -s base -b "cn=' + user.strip + ',ou=users,ou=trash,dc=example,dc=tld" "(&(objectClass=applicationProcess)(status=totrash))" | grep otherPath: | sed "s|.*: \(.*\)|\1|"')
+         trashname = Facter::Util::Resolution.exec('ldapsearch -H ldapi:// -Y EXTERNAL -LLL -s base -b "cn=' + user.strip + ',ou=users,ou=trash,dc=example,dc=tld" "(&(objectClass=applicationProcess)(status=totrash))" | grep type: | sed "s|.*: \(.*\)|\1|"')
          orphanhomes[user.strip] = {:uid => user.strip, :home => userhome.strip, :trashname => trashname.strip}
         end
       end


### PR DESCRIPTION
'cn' is the only required attribute for objectClass applicationProcess .
otherPath for /home/directory is an attribute from Yap object which is an IA5 type string (same as homeDirectory)